### PR TITLE
jobs now render immediately after they're entered on the Jobs page

### DIFF
--- a/components/JobModal.js
+++ b/components/JobModal.js
@@ -55,6 +55,9 @@ export default class JobModal extends React.Component {
   };
 
   handleSubmit = () => {
+    let newJobs = this.props.jobs;
+    newJobs.push(this.state);
+    this.props.setJobs(newJobs);
     Geocode.setApiKey(process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY);
     var latVal;
     var lngVal;
@@ -65,7 +68,6 @@ export default class JobModal extends React.Component {
       this.setState({
         coordinates: { lat: latVal, lng: lngVal },
       })
-      console.log('without state ref:', latVal, lngVal);
       setTimeout(() => axios.post("http://ec2-18-221-69-122.us-east-2.compute.amazonaws.com:8080/addjob", this.state), 250); // Temporary Fix
     })
     .then(this.props.handleClose)

--- a/pages/clientportal.js
+++ b/pages/clientportal.js
@@ -19,12 +19,11 @@ export default function Jobs() {
     axios
       .get(`http://ec2-18-221-69-122.us-east-2.compute.amazonaws.com:8080/getJobs/${user.email}`)
       .then((response) => {
-        console.log(response);
         setJobs(response.data);
       })
       .catch((err) => console.log(err));
       }
-  }, [show, user]);
+  }, [user]);
 
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
@@ -53,7 +52,7 @@ export default function Jobs() {
             <button className={styles.addJobBtn} onClick={handleShow}>
               + &nbsp;ADD A JOB
             </button>
-            <JobModal show={show} handleClose={handleClose} email={user.email}/>
+            <JobModal show={show} handleClose={handleClose} email={user.email} setJobs={setJobs} jobs={jobs}/>
           </div>
         </>
       ) : (


### PR DESCRIPTION
When a user submits a job request, it will now render immediately to the screen.